### PR TITLE
Modify the algorithm to calculate steering angle

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -115,7 +115,7 @@ def draw_lanes(lanes=None, left_lane=None, right_lane=None, image=None):
   return background
 
 
-def display_heading_line(image, left_lane, right_lane, steering_angle):
+def display_heading_line(image, left_lane, right_lane, path_points):
     """
     Draws heading line on the image based on left and right lane coordinates and steering angle.
 
@@ -135,17 +135,11 @@ def display_heading_line(image, left_lane, right_lane, steering_angle):
     for x, y in zip(right_lane['x'], right_lane['y']):
       image_with_line[y, x] = 255
 
-    height, width = image_with_line.shape[:2]
-    center_x, center_y = width // 2, height
-    line_length = height // 3  # Adjust the length of the heading line as needed
-    angle_radians = np.deg2rad(180 - steering_angle)  # Convert to radians
+    x_coords, y_coords = zip(*path_points)
+    x_coords_selected = x_coords[::10]
+    y_coords_selected = y_coords[::10]
 
-    # Calculate end point of the heading line
-    end_x = int(center_x + line_length * np.cos(angle_radians))
-    end_y = int(center_y - line_length * np.sin(angle_radians))
-
-    image_with_line = cv2.line(image_with_line, (center_x, center_y), (end_x, end_y), (0, 0, 255), 3)
-
+    plt.plot(x_coords_selected, y_coords_selected, 'ro', markersize=5, linewidth=2, color='green')
     plt.imshow(image_with_line)
     plt.show()
 
@@ -161,7 +155,7 @@ def predict(image, model=None):
   df_lanes = HDBSCAN_cluster(lanes_coords)
   left_lane, right_lane = extract_current_lanes(df_lanes=df_lanes) # return dataframe x, y coordinates
   path_points = calculate_ideal_path(left_lane=left_lane, right_lane=right_lane)
-  draw_lanes(lanes=path_points, image=np.copy(image))
+  display_heading_line(image, left_lane, right_lane, path_points)
   # steering_angle = calculate_steer_angle(left_lane, right_lane, width=512, height=256)
   # display_heading_line(image, left_lane, right_lane, steering_angle)
   return None

--- a/src/predict.py
+++ b/src/predict.py
@@ -68,23 +68,6 @@ def calculate_ideal_path(left_lane=None, right_lane=None, height=256):
 
   return ideal_path
 
-
-def calculate_steer_angle(left_lane=None, right_lane=None, width=512, height=256):
-  """
-  Calculates the steering angle based on the predicted mask
-  """
-  mid = width // 2
-  left_mid_x = left_lane['x'].mean()
-  right_mid_x = right_lane['x'].mean()
-
-  x_offset = (left_mid_x + right_mid_x) / 2 - mid
-  y_offset = int(height * 0.6)
-
-  angle_to_mid_radian = np.arctan(x_offset / y_offset)
-  angle_to_mid_deg = np.degrees(angle_to_mid_radian)
-  steering_angle = angle_to_mid_deg + 90
-  return steering_angle
-
 def pure_pursuit(reference_path=None, width=512, height=256):
   """
   Calculates the steering angle based on the reference path
@@ -98,15 +81,16 @@ def pure_pursuit(reference_path=None, width=512, height=256):
 
   lookahead_point = None
   for point in reversed(reference_path):
-    if math.hypot(point[0] - vehicle_position[0], vehicle_position[1] - point[1]) > lookahead_distance:
+    distance = vehicle_position[1] - point[1] # should be Euclidean Algorithm but this doesn't work sometimes for some reason
+    if  distance >= lookahead_distance:
       lookahead_point = point
       break
 
   if lookahead_point is None:
     return None
 
+  print(lookahead_point)
   angle_to_lookahead_radian = np.arctan2(vehicle_position[1] - lookahead_point[1], lookahead_point[0] - vehicle_position[0])
-
   return angle_to_lookahead_radian
 
 
@@ -185,5 +169,5 @@ def predict(image, model=None):
 Lane = LaneDataset(train=True)
 SAMPLE_IMAGES = Lane.X_train
 model = keras.models.load_model(os.getenv('MODEL_PATH'), custom_objects={'dice_coef': dice_coef, 'dice_loss': dice_loss})
-for img in SAMPLE_IMAGES.take(5):
+for img in SAMPLE_IMAGES.take(10):
   predict(img, model)


### PR DESCRIPTION
features what I did for this PR are
- changed the algorithm from optimistic to strict way
So far we calculate lookahead point from right lane mean and left lane mean. This time, I changed it to calculate them from ideal path pixels

<img src="https://github.com/SEAME-TEAM01/ADS01-Lane-Keeping-Assist/assets/98635404/4ab21d6c-24d6-4b61-9048-05b4a24c4f67" width=300/>
<img src="https://github.com/SEAME-TEAM01/ADS01-Lane-Keeping-Assist/assets/98635404/64d3f4e1-8087-4418-83f3-75e0821c34b0" width=300/>
<img src="https://github.com/SEAME-TEAM01/ADS01-Lane-Keeping-Assist/assets/98635404/e5423ad8-c0f0-4ac8-a6f1-57ca6f0edf4f" width=300/>


### fix  #20 